### PR TITLE
accept .treefmt.toml

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,10 @@ async function readConfig() {
 	if (treefmtTomlPath) {
 		configPath = treefmtTomlPath;
 	} else {
-		configPath = path.join(workspaceRoot ?? "", "treefmt.toml");
+		configPath = path.join(workspaceRoot ?? "", ".treefmt.toml");
+		if (!fs.existsSync(configPath)) {
+			configPath = path.join(workspaceRoot ?? "", "treefmt.toml");
+		}
 	}
 }
 


### PR DESCRIPTION
treefmt itself accepts `treefmt.toml` as well as `.treefmt.toml`.
The vs code extension should do the same
