### PR TITLE
Make config optional and improve error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "treefmt-vscode",
 	"displayName": "treefmt-vscode",
 	"description": "treefmt streamlines the process of applying formatters to your project, making it a breeze with just one command line.",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"publisher": "ibecker",
 	"icon": "icon.png",
 	"engines": {


### PR DESCRIPTION
I moved the offer of calling `treefmt --init` into the error handling area, so that it is only called if there is an error calling treefmt. This allows treefmt to run 'bare', as in without any config file specified. Thus, allowing the feature proposed in #3 to function.

This is also a better user experience.

Fixes #3