### PR TITLE
Use `path.basename` to prevent empty `stdin` arg

### DIFF
--- a/src/treefmtUtils.ts
+++ b/src/treefmtUtils.ts
@@ -190,7 +190,7 @@ export async function getFormattedTextFromTreefmt(
 		args += ` --config-file=${configPath}`;
 	}
 
-	const fileExtension = path.extname(editor.document.fileName);
+	const fileExtension = path.basename(editor.document.fileName);
 	args += ` --stdin ${fileExtension}`;
 
 	const fullCommand = `${command} ${args}`;


### PR DESCRIPTION
Fixes #9